### PR TITLE
MNT: on unstage re-set the filename

### DIFF
--- a/startup/10-area-detector.py
+++ b/startup/10-area-detector.py
@@ -80,9 +80,10 @@ class AndorKlass(SingleTriggerV33, DetectorBase):
         return super().resume()
 
     def unstage(self, *args, **kwargs):
-        super().unstage()
+        ret = super().unstage()
         from ophyd.utils import set_and_wait
         set_and_wait(self.hdf5.file_name, 'jibberish', timeout=5*60)
+        return ret
 
 
 class Manta(SingleTrigger, AreaDetector):

--- a/startup/10-area-detector.py
+++ b/startup/10-area-detector.py
@@ -79,6 +79,12 @@ class AndorKlass(SingleTriggerV33, DetectorBase):
         self.hdf5.capture.put(1)
         return super().resume()
 
+    def unstage(self, *args, **kwargs):
+        super().unstage()
+        from ophyd.utils import set_and_wait
+        set_and_wait(self.hdf5.file_name, 'jibberish', timeout=5*60)
+
+
 class Manta(SingleTrigger, AreaDetector):
     image = Cpt(ImagePlugin, 'image1:')
     stats1 = Cpt(StatsPluginV33, 'Stats1:')


### PR DESCRIPTION
This will exercise the filesystem issues on the way out of the
scan (with an _absurd_ timeout).  This is less than ideal, but it will
hopefully allow users to take data.