### PR TITLE
Fix `_set_cam_chunk_size`: use `bps.unstage`/`bps.stage`

### DIFF
--- a/startup/40-scan_pre_define.py
+++ b/startup/40-scan_pre_define.py
@@ -80,16 +80,8 @@ def _set_cam_chunk_size(detectors, chunk_size, scan_type='fly'):
 
 
     for detector in detectors:
-        #print(f'try to unstage:\n {detector}\n')
-        #yield from unstage(detector)
-        try:
-            detector.unstage()
-        except Exception as e:
-            print(e)
-            pass
-        #print('sleep 0.2 sec')
+        yield from bps.unstage(detector)
         yield from bps.sleep(0.2)
-
 
     yield from mv(detectors[0].cam.acquire, 0)
     yield from bps.sleep(0.2)
@@ -98,13 +90,17 @@ def _set_cam_chunk_size(detectors, chunk_size, scan_type='fly'):
     yield from mv(detectors[0].cam.trigger_mode, trigger_mode_id)
     yield from bps.sleep(0.2)
     yield from mv(detectors[0].cam.num_images, chunk_size)
+    # bps.configure re-prepares all stream descriptors that include this detector using
+    # _current_stream_cache. That cache only holds objects from the most recently active
+    # stream, so any stream set up WITHOUT motors (e.g. "flat") must not be the last
+    # active stream before this call — otherwise descriptor re-preparation raises a
+    # KeyError for motors. See test_scan2 for the enforced dark → primary → background order.
     yield from bps.configure(detectors[0], {})
     yield from bps.sleep(0.2)
 
     for detector in detectors:
         yield from bps.sleep(0.2)
-        #yield from stage(detector)
-        detector.stage()
+        yield from bps.stage(detector)
 
 
 def _take_dark_image(

--- a/startup/44-scans_other.py
+++ b/startup/44-scans_other.py
@@ -267,7 +267,13 @@ def test_scan2(
     @stage_decorator(list(detectors) + motors)
     @run_decorator(md=_md)
     def inner_scan():
-        # close shutter, dark images: numer=chunk_size (e.g.20)
+        # Order matters: dark → primary → background.
+        # bps.configure (inside _set_cam_chunk_size) re-prepares stream descriptors using
+        # _current_stream_cache. The background ("flat") stream reads NO motors, so after
+        # it runs _current_stream_cache has no motors. Calling bps.configure afterwards
+        # would try to re-prepare the "dark" descriptor (which has motors) against that
+        # motors-free cache → KeyError. Primary must come before background so that motors
+        # remain in _current_stream_cache when bps.configure runs before the flat stream.
         if take_dark_img:
             print("\nshutter closed, taking dark images...")
             yield from _take_dark_image(detectors, motors, num=1, chunk_size=20, stream_name="dark", simu=simu)


### PR DESCRIPTION
Replace direct `detector.unstage()`/`detector.stage()` calls with bluesky plan primitives `bps.unstage()`/`bps.stage()` so bluesky's staged-objects registry stays consistent and errors during unstage are not silently swallowed.

Why the error happened before:

1. bps.configure triggers _current_stream_cache-based descriptor re-preparation
2. test_scan2 must use dark → primary → background order (background stream omits motors, leaving _current_stream_cache without motors; a subsequent bps.configure would then KeyError when re-preparing the motor-inclusive 'dark' descriptor).

Need to test it at the beamline before merging.