### PR TITLE
update Tiled clients to direct to acquisition cluster

### DIFF
--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -65,6 +65,7 @@ if not is_re_worker_active():
 from bluesky.preprocessors import stage_decorator, run_decorator
 
 tiled_writing_client = from_profile("nsls2", api_key=os.getenv("TILED_BLUESKY_WRITING_API_KEY_FXI", ""))["fxi"]["raw"]
+tiled_writing_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 class TiledInserter:
     name = 'fxi'
@@ -76,6 +77,7 @@ tiled_inserter = TiledInserter()
 
 if not is_re_worker_active():
     db = tiled_reading_client = from_profile("nsls2", include_data_sources=True)["fxi"]["raw"]
+    db.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 nslsii.configure_base(get_ipython().user_ns,
                       tiled_inserter,

--- a/startup/82-load_scan_tiled.py
+++ b/startup/82-load_scan_tiled.py
@@ -13,6 +13,7 @@ from skimage import io
 
 CATALOG_NAME = "fxi"
 tiled_client = from_uri("https://tiled.nsls2.bnl.gov")[CATALOG_NAME]
+tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 raw = tiled_client_fxi = tiled_client["raw"]
 
 


### PR DESCRIPTION
Add item that directs use of Tiled acquisition cluster to be used while acquiring data. Tiled clients from Prefect workflows, Jupyter notebooks, and other sources will be isolated from the acquisition cluster, ensuring data acquisition is not negatively affected by non-acquisition Tiled requests.